### PR TITLE
Fix compatibility to clickable 5.0

### DIFF
--- a/README-Developers.md
+++ b/README-Developers.md
@@ -4,7 +4,7 @@ Building and running on Desktop
 Building and running the Ubuntu Music App is quite simple with clickable:
 
 ```
-clickable -e
+clickable desktop
 ```
 
 Debugging on the Desktop is recommended. The autopilot tests in this repository

--- a/clickable.json
+++ b/clickable.json
@@ -1,5 +1,4 @@
 {
     "template": "cmake",
-    "sdk": "ubuntu-sdk-16.04",
     "arch": "all"
 }


### PR DESCRIPTION
The `sdk` has been removed in clickable 5.0. Xenial now is the default. 